### PR TITLE
Fixed a bug with georeferencing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Date: 2014-02-07
 Title: programmatic interface to the AntWeb
 Description: A complete programmatic interface to the AntWeb database from the
     California Academy of Sciences.
-Version: 0.4
+Version: 0.5
 Authors@R: 'Karthik Ram <karthik.ram@gmail.com> [aut, cre]'
 Depends:
     R (>= 3.0.1)

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+
+Version: 0.5
+=============
+* Bug fixes related to lat/long being renamed.
+
+
 Version: 0.4
 =============
 * Initial CRAN release
+

--- a/R/aw_data.R
+++ b/R/aw_data.R
@@ -14,6 +14,7 @@
 #' @return data.frame
 #' @examples   
 #' data <- aw_data(genus = "acanthognathus", species = "brevicornis")
+#' data3 <- aw_data(genus = "acanthognathus", species = "brevicornis", georeferenced = TRUE)
 #' # data2 <- aw_data(scientific_name = "acanthognathus brevicornis")
 #' # data_genus_only <- aw_data(genus = "acanthognathus")
 #' # leaf_cutter_ants  <- aw_data(genus = "acromyrmex")
@@ -42,12 +43,14 @@ aw_data <- function(genus = NULL, species = NULL, scientific_name = NULL, georef
 	df
 })
 	final_df <- data.frame(do.call(rbind.fill, data_df))
+	names(final_df)[grep("latitude", names(final_df))] <- "decimal_latitude"
+	names(final_df)[grep("longitude", names(final_df))] <- "decimal_longitude"
+
 	final_df$meta.other <- NULL
 	if(!georeferenced) {
 		final_df
 	} else {
-		# dplyr::filter(final_df, !is.na(meta.decimal_latitude), !is.na(meta.decimal_longitude))
-		subset(final_df, !is.na(meta.decimal_latitude) & !is.na(meta.decimal_longitude))
+		subset(final_df, !is.na(decimal_latitude) & !is.na(decimal_longitude))
 	}
 
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ install_github("ropensci/AntWeb")
 To cite package ‘AntWeb’ in publications use:
 
   'Karthik Ram' (2014). AntWeb: programmatic interface
-  to the AntWeb. R package version 0.4.
+  to the AntWeb. R package version 0.5.
   https://github.com/ropensci/AntWeb
 
 A BibTeX entry for LaTeX users is
@@ -54,7 +54,7 @@ A BibTeX entry for LaTeX users is
     title = {AntWeb: programmatic interface to the AntWeb},
     author = {'Karthik Ram'},
     year = {2014},
-    note = {R package version 0.4},
+    note = {R package version 0.5},
     url = {https://github.com/ropensci/AntWeb},
   }
 

--- a/man/aw_data.Rd
+++ b/man/aw_data.Rd
@@ -28,6 +28,7 @@ any taxonomic rank or full species name.
 }
 \examples{
 data <- aw_data(genus = "acanthognathus", species = "brevicornis")
+data3 <- aw_data(genus = "acanthognathus", species = "brevicornis", georeferenced = TRUE)
 # data2 <- aw_data(scientific_name = "acanthognathus brevicornis")
 # data_genus_only <- aw_data(genus = "acanthognathus")
 # leaf_cutter_ants  <- aw_data(genus = "acromyrmex")

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -2,7 +2,11 @@
 context("Ant Data")
 
 test_that("We are able to retreive all ant data correctly", {
+	# This will also test that georeferencing works correctly
 	ad <- aw_data(genus = "acanthognathus", species = "brevicornis")
+	ad2 <- aw_data(genus = "acanthognathus", species = "brevicornis", georeferenced = TRUE)
+	expect_true((nrow(ad) - nrow(ad2)) > 0)
+
 	expect_is(ad, "data.frame")
 	expect_error(aw_data())
 })


### PR DESCRIPTION
Issue was that some calls were returning `meta.decimal_latitude` and others `decimal_latitude`. This fix renames both to `decimal_latitude`.
